### PR TITLE
Unlock all Veteran Content for everyone

### DIFF
--- a/modular_skyrat/modules/veteran_players/code/veteran_players.dm
+++ b/modular_skyrat/modules/veteran_players/code/veteran_players.dm
@@ -20,6 +20,7 @@ GLOBAL_LIST(veteran_players)
 /proc/is_veteran_player(client/user)
 	if(isnull(user))
 		return FALSE
+	return TRUE //Bubberstation Edit, unlocks all Veteran features for everyone
 	if(GLOB.veteran_players[user.ckey])
 		return TRUE
 	if(check_rights_for(user, R_ADMIN))


### PR DESCRIPTION
## About The Pull Request
Makes everyone a veteran to unlock all Veteran content.
Note that this is a a quick hack before I go to bed. I did not test this at all. There are probably better ways to do this.
I PR'ed it anyway in case you want it for now.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Everyone has access to previously Veteran-only content now!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
