### PR TITLE
Gives Lone Infiltrator more TC.

### DIFF
--- a/code/game/objects/items/implants/implantuplink.dm
+++ b/code/game/objects/items/implants/implantuplink.dm
@@ -59,4 +59,4 @@
 	starting_tc = TELECRYSTALS_PRELOADED_IMPLANT
 
 /obj/item/implant/uplink/starting
-	starting_tc = TELECRYSTALS_DEFAULT - UPLINK_IMPLANT_TELECRYSTAL_COST
+	starting_tc = 32


### PR DESCRIPTION
## About The Pull Request

Gives Lone Infil more tc, because skyrat's choices are weird

## How This Contributes To The Bubberstation Experience

Half of the fun of being antagonist, for me at least, is the ability to play around with fun gadgets. When I literally get 16 TC which s less than a basic bitch traitor, being a trained infiltrator trusted by the syndicate, i have no fucking idea how this makes any sense. Any viable gun costs more than 10 tc, what are you going to do with the rest, buy a mag and noslips and have fun. Seriously just... Skyrat took TC away from loneop because they were salty that he ends rounds. Infltrator doesn't end rounds so idk why it's still 16tc.

## Proof of Testing

I'm not going to test a number change webedit

## Changelog

:cl:
balance: Changed TC amount for infiltrator
/:cl:
